### PR TITLE
Fix the word carácter everywhere

### DIFF
--- a/core/datastructures/files.rst
+++ b/core/datastructures/files.rst
@@ -169,7 +169,7 @@ En el caso que nos ocupa, usaremos la sentencia ``with`` y el contexto creado se
 **Línea 2**
     Lectura del fichero línea a línea utilizando la iteración sobre el *manejador del fichero*.
 **Línea 3**
-    Limpieza de saltos de línea con ``strip()`` encadenando la función ``split()`` para separar las dos temperaturas por el caracter *espacio*. Ver :ref:`limpiar una cadena <core/datatypes/strings:Limpiar cadenas>` y :ref:`dividir una cadena <core/datatypes/strings:Dividir una cadena>`.
+    Limpieza de saltos de línea con ``strip()`` encadenando la función ``split()`` para separar las dos temperaturas por el carácter *espacio*. Ver :ref:`limpiar una cadena <core/datatypes/strings:Limpiar cadenas>` y :ref:`dividir una cadena <core/datatypes/strings:Dividir una cadena>`.
 **Línea 4**
     Imprimir por pantalla la temperatura mínima y la máxima.
 

--- a/core/datastructures/lists.rst
+++ b/core/datastructures/lists.rst
@@ -54,7 +54,7 @@ Para convertir otros tipos de datos en una lista podemos usar la función ``list
     >>> list('Python')
     ['P', 'y', 't', 'h', 'o', 'n']
 
-Si nos fijamos en lo que ha pasado, al convertir la cadena de texto ``Python`` se ha creado una lista con *6* elementos, donde cada uno de ellos representa un caracter de la cadena. Podemos *extender* este comportamiento a cualquier otro tipo de datos que permita ser iterado (*iterables*).
+Si nos fijamos en lo que ha pasado, al convertir la cadena de texto ``Python`` se ha creado una lista con *6* elementos, donde cada uno de ellos representa un carácter de la cadena. Podemos *extender* este comportamiento a cualquier otro tipo de datos que permita ser iterado (*iterables*).
 
 Lista vacía
 ===========
@@ -73,7 +73,7 @@ Operaciones con listas
 Obtener un elemento
 ===================
 
-Igual que en el caso de las :ref:`cadenas de texto <core/datatypes/strings:Obtener un caracter>`, podemos obtener un elemento de una lista a través del **índice** (lugar) que ocupa. Veamos un ejemplo::
+Igual que en el caso de las :ref:`cadenas de texto <core/datatypes/strings:Obtener un carácter>`, podemos obtener un elemento de una lista a través del **índice** (lugar) que ocupa. Veamos un ejemplo::
 
     >>> shopping = ['Agua', 'Huevos', 'Aceite']
 

--- a/core/datatypes/data.rst
+++ b/core/datatypes/data.rst
@@ -167,7 +167,7 @@ Recordemos que los nombres de variables deben seguir unas :ref:`reglas estableci
             ^
     SyntaxError: invalid syntax
 
-    >>> screen-size = 14  # el nombre usa un caracter no válido
+    >>> screen-size = 14  # el nombre usa un carácter no válido
       File "<stdin>", line 1
     SyntaxError: can't assign to operator
 

--- a/core/datatypes/strings.rst
+++ b/core/datatypes/strings.rst
@@ -53,7 +53,7 @@ Hay una forma alternativa de crear cadenas de texto utilizando *comillas triples
 Cadena vacía
 ============
 
-La cadena vacía es aquella que no contiene ningún caracter. Aunque a priori no lo pueda parecer, es un recurso importante en cualquier código. Su representación en Python es la siguiente:
+La cadena vacía es aquella que no contiene ningún carácter. Aunque a priori no lo pueda parecer, es un recurso importante en cualquier código. Su representación en Python es la siguiente:
 
     >>> ''
     ''
@@ -75,7 +75,7 @@ Podemos crear "strings" a partir de otros tipos de datos usando la función ``st
 Secuencias de escape
 ********************
 
-Python permite **escapar** el significado de algunos caracteres para conseguir otros resultados. Si escribimos una barra invertida ``\`` antes del caracter en cuestión, le otorgamos un significado especial.
+Python permite **escapar** el significado de algunos caracteres para conseguir otros resultados. Si escribimos una barra invertida ``\`` antes del carácter en cuestión, le otorgamos un significado especial.
 
 Quizás la *secuencia de escape* más conocida es ``\n`` que representa un *salto de línea*, pero existen muchas otras::
 
@@ -158,9 +158,9 @@ Hemos estado utilizando la función ``print()`` de forma sencilla, pero admite `
 *Línea 4:*
     Podemos imprimir todas las variables que queramos separándolas por comas.
 *Línea 7:*
-    El *separador por defecto* entre las variables es un *espacio*, podemos cambiar el caracter que se utiliza como separador entre cadenas.
+    El *separador por defecto* entre las variables es un *espacio*, podemos cambiar el carácter que se utiliza como separador entre cadenas.
 *Línea 10:*
-    El *carácter de final de texto* es un *salto de línea*, podemos cambiar el caracter que se utiliza como final de texto.
+    El *carácter de final de texto* es un *salto de línea*, podemos cambiar el carácter que se utiliza como final de texto.
 
 ************************
 Leer datos desde teclado
@@ -233,10 +233,10 @@ Podemos repetir dos o más cadenas de texto utilizando el operador ``*``::
     >>> reaction * 4
     'WowWowWowWow'
 
-Obtener un caracter
+Obtener un carácter
 ===================
 
-Los "strings" están **indexados** y cada caracter tiene su propia posición. Para obtener un único caracter dentro de una cadena de texto es necesario especificar su **índice** dentro de corchetes ``[...]``.
+Los "strings" están **indexados** y cada carácter tiene su propia posición. Para obtener un único carácter dentro de una cadena de texto es necesario especificar su **índice** dentro de corchetes ``[...]``.
 
 .. figure:: img/string-indexing.jpg
     :align: center
@@ -256,7 +256,7 @@ Veamos algunos ejemplos de acceso a caracteres::
     >>> sentence[-5]
     'M'
 
-.. tip:: Nótese que existen tanto **índices positivos** como **índices negativos** para acceder a cada caracter de la cadena de texto. A priori puede parecer redundante, pero es muy útil en determinados casos.
+.. tip:: Nótese que existen tanto **índices positivos** como **índices negativos** para acceder a cada carácter de la cadena de texto. A priori puede parecer redundante, pero es muy útil en determinados casos.
 
 En caso de que intentemos acceder a un índice que no existe, obtendremos un error por *fuera de rango*:
 
@@ -267,7 +267,7 @@ En caso de que intentemos acceder a un índice que no existe, obtendremos un err
 
 .. warning:: Téngase en cuenta que el indexado de una cadena de texto siempre empieza en **0** y termina en **una unidad menos de la longitud** de la cadena.
 
-Las cadenas de texto son tipos de datos :ref:`inmutables <core/datatypes/data:Mutabilidad>`. Es por ello que no podemos modificar un caracter directamente::
+Las cadenas de texto son tipos de datos :ref:`inmutables <core/datatypes/data:Mutabilidad>`. Es por ello que no podemos modificar un carácter directamente::
 
     >>> song = 'Hey Jude'
 

--- a/core/datatypes/tables/var-naming.csv
+++ b/core/datatypes/tables/var-naming.csv
@@ -1,6 +1,6 @@
 Válido,Inválido,Razón
  ``a``,``3``,Empieza por un dígito
  ``a3``,``3a``,Empieza por un dígito
- ``a_b_c___95``,``another-name``,Contiene un caracter no permitido
+ ``a_b_c___95``,``another-name``,Contiene un carácter no permitido
  ``_abc``,``with``,Es una palabra reservada del lenguaje 
  ``_3a``,``3_a``,Empieza por un dígito 


### PR DESCRIPTION
# 🤓 What are we doing here

Replacing all "caracter" with "carácter". Small contribution, I know, but we build big things with small bricks ;)

Singular: carácter
Plural: caracteres

Other combinations do not exist in Spanish.

> carácter. 1. ‘Conjunto de rasgos característicos’ y ‘signo de la escritura’. Es voz llana y se pronuncia [karákter], no [karaktér]. En el plural, el acento prosódico pasa de la a a la e: caracteres (pron. [karaktéres]), no carácteres.
-- [Diccionario panhispánico de dudas](https://www.rae.es/dpd/car%C3%A1cter)
